### PR TITLE
fix: pragmatic fix for expired api key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ FE_SOURCE_DIR=frontend
 BUCKET_NAME=reporadar-bucket-$(AWS_REGION)-$(ENVIRONMENT)
 STACK_NAME=reporadar-$(ENVIRONMENT)
 
+NOW=${shell date -u +%s}
+GRAPHQL_API_KEY_TIME_TO_LIVE=$$(( 60 * 60 * 24 * 365 ))
+GRAPHQL_API_KEY_EXPIRATION_DATE=$$(( $(NOW) + $(GRAPHQL_API_KEY_TIME_TO_LIVE) ))
+
 export AWS_REGION
 export AWS_DEFAULT_REGION
 
@@ -67,7 +71,7 @@ deploy-api: guard-ENVIRONMENT guard-GITHUB_ACCESS_TOKEN
 		--template-file packaged.yaml \
 		--stack-name ${STACK_NAME} \
 		--capabilities CAPABILITY_NAMED_IAM \
-		--parameter-overrides Environment=${ENVIRONMENT} GitHubAccessToken=${GITHUB_ACCESS_TOKEN} \
+		--parameter-overrides Environment=${ENVIRONMENT} GitHubAccessToken=${GITHUB_ACCESS_TOKEN} GraphQLApiKeyExpirationDate=${GRAPHQL_API_KEY_EXPIRATION_DATE} \
 		--no-fail-on-empty-changeset
 
 deploy-fe:

--- a/template.yaml
+++ b/template.yaml
@@ -7,6 +7,8 @@ Parameters:
     Type: String
   GitHubAccessToken:
     Type: String
+  GraphQLApiKeyExpirationDate:
+    Type: String
 
 Globals:
   Function:
@@ -87,11 +89,12 @@ Resources:
       Name: !Sub RepoRadar GraphQL API (${Environment})
       AuthenticationType: API_KEY
 
-  GraphQLApiApiKey:
+  GraphQLApiApiKey3:
     Type: AWS::AppSync::ApiKey
     Properties:
-      Description: RepoRadar GraphQL API Key
+      Description: !Sub RepoRadar GraphQL API Key (${GraphQLApiKeyExpirationDate})
       ApiId: !GetAtt GraphQLApi.ApiId
+      Expires: !Ref GraphQLApiKeyExpirationDate
 
   RepoTableDataSource:
     Type: "AWS::AppSync::DataSource"
@@ -187,7 +190,7 @@ Resources:
               ]
             OriginCustomHeaders:
               - HeaderName: x-api-key
-                HeaderValue: !GetAtt GraphQLApiApiKey.ApiKey
+                HeaderValue: !GetAtt GraphQLApiApiKey3.ApiKey
             CustomOriginConfig:
               HTTPPort: 80
               HTTPSPort: 443


### PR DESCRIPTION
right now the key is just valid for one year and might break the system next year. creating a public graphql api is kinda tricky and i just wanna postpone the problem for now.